### PR TITLE
fix: missing predefined display name on stateless components

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,9 +27,10 @@ component:(_temp=_class=function(_Component){_inherits(_class,_Component);functi
 
 
 
+
 {
 return component(this.props);
-}}]);return _class;}(_react.Component),_class.propTypes=component.propTypes,_class.defaultProps=component.defaultProps,_temp);var
+}}]);return _class;}(_react.Component),_class.propTypes=component.propTypes,_class.defaultProps=component.defaultProps,_class.displayName=component.displayName,_temp);var
 
 
 Uranium=function(_ComposedComponent){_inherits(Uranium,_ComposedComponent);function Uranium(){var _ref;var _temp2,_this2,_ret;_classCallCheck(this,Uranium);for(var _len=arguments.length,args=Array(_len),_key=0;_key<_len;_key++){args[_key]=arguments[_key];}return _ret=(_temp2=(_this2=_possibleConstructorReturn(this,(_ref=Uranium.__proto__||Object.getPrototypeOf(Uranium)).call.apply(_ref,[this].concat(args))),_this2),_this2.

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export default component => {
     class extends Component {
       static propTypes = component.propTypes;
       static defaultProps = component.defaultProps;
+      static displayName = component.displayName;
 
       render() {
         return component(this.props)


### PR DESCRIPTION
### What problem does this PR solve?
Predefined `displayName` is missing on stateless components.
It makes testing (snapshot) and debugging (`react devtools`) quite vague and difficult to know exactly the component name. 

Assume that we have a simple component

```js
const ItemTitle = () => <View />
ItemTitle.displayName = 'ItemTitle'
const ItemTitleComponent = Uranium(ItemTitle)
```

* Actual:

```js
console.log(ItemTitleComponent.displayName) // Uranium(_class)
```
* Expected:
```js
console.log(ItemTitleComponent.displayName) // Uranium(ItemTitle)
```

### How does this PR solve it?

Re-assign the static `displayName` when initializing a new React component.

@tuckerconnelly 